### PR TITLE
Create metrics only for specific endpoints to not flood prometheus

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -17,7 +17,7 @@ from pipes import quote
 from prometheus import prometheus_metrics
 
 @Request.application
-@prometheus_metrics('/metrics')
+@prometheus_metrics('/metrics', ('/', '/healthz'))
 def application(request):
 
     if request.method == 'GET':

--- a/src/prometheus.py
+++ b/src/prometheus.py
@@ -19,12 +19,12 @@ def prometheus_metrics(metrics_path, monitor_endpoints):
     def prometheus_metrics_decorator(f):
         @wraps(f)
         def f_wrapper(request):
-            start_time = time()
             # Create metrics only for specific endpoints to not flood
             # prometheus with dynamically created labels.
             if request.path not in monitor_endpoints:
                 return f(request)
 
+            start_time = time()
             if request.method == 'GET' and request.path == metrics_path:
                 status = 200
                 REQUEST_LATENCIES.labels(

--- a/src/prometheus.py
+++ b/src/prometheus.py
@@ -14,11 +14,16 @@ REQUEST_LATENCIES = Histogram(
     ['method', 'endpoint', 'code']
 )
 
-def prometheus_metrics(metrics_path):
+def prometheus_metrics(metrics_path, monitor_endpoints):
+    monitor_endpoints = set([metrics_path] + list(monitor_endpoints))
     def prometheus_metrics_decorator(f):
         @wraps(f)
         def f_wrapper(request):
             start_time = time()
+            # Create metrics only for specific endpoints to not flood
+            # prometheus with dynamically created labels.
+            if request.path not in monitor_endpoints:
+                return f(request)
 
             if request.method == 'GET' and request.path == metrics_path:
                 status = 200


### PR DESCRIPTION
Metrics are created for /, /healthz and /metrics endpoints only to avoid dynamic generation of masses of different time series (labels).
