### PR TITLE
Don't expose metrics on production port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
 ADD src/* /
-EXPOSE 5555
+EXPOSE 5555 9191
 
 ENTRYPOINT ["usr/local/bin/gunicorn"]
 
-CMD ["-b", "0.0.0.0:5555", "--log-file", "-", "app:application"]
+CMD ["-b", "0.0.0.0:5555", "-b", "0.0.0.0:9191", "--log-file", "-", "app:application"]

--- a/src/app.py
+++ b/src/app.py
@@ -17,9 +17,8 @@ from pipes import quote
 from prometheus import prometheus_metrics
 
 @Request.application
-@prometheus_metrics('/metrics', ('/', '/healthz'))
+@prometheus_metrics(9191, '/metrics', ('/', '/healthz'))
 def application(request):
-
     if request.method == 'GET':
         return Response(status=status.OK)
 


### PR DESCRIPTION
- /metrics endpoint is now exposed via port 9191 only. This closes #13.
- Remove some duplicate code in case of /metrics request.
- Reorder if clause to match as early as possible.
